### PR TITLE
childviewcontroller

### DIFF
--- a/ICViewPager/ICViewPager/ViewPagerController.m
+++ b/ICViewPager/ICViewPager/ViewPagerController.m
@@ -288,7 +288,8 @@
     _pageViewController = [[UIPageViewController alloc] initWithTransitionStyle:UIPageViewControllerTransitionStyleScroll
                                                           navigationOrientation:UIPageViewControllerNavigationOrientationHorizontal
                                                                         options:nil];
-    
+    [self addChildViewController:_pageViewController];
+
     //Setup some forwarding events to hijack the scrollview
     self.origPageScrollViewDelegate = ((UIScrollView*)[_pageViewController.view.subviews objectAtIndex:0]).delegate;
     [((UIScrollView*)[_pageViewController.view.subviews objectAtIndex:0]) setDelegate:self];


### PR DESCRIPTION
Adds the uipageviewcontroller as a child view controller. This way, from the pageviewcontroller pages, you can recover higher level parents, and navigation controller if the uipageviewcontroller is embedded in a navigation controller, for instance.
