### PR TITLE
Fix UI jerkiness when calling selectTabAtIndex

### DIFF
--- a/ICViewPager/ICViewPager/ViewPagerController.m
+++ b/ICViewPager/ICViewPager/ViewPagerController.m
@@ -194,8 +194,6 @@
 #pragma mark - IBAction
 - (IBAction)handleTapGesture:(id)sender {
     
-    self.animatingToTab = YES;
-    
     // Get the desired page's index
     UITapGestureRecognizer *tapGestureRecognizer = (UITapGestureRecognizer *)sender;
     UIView *tabView = tapGestureRecognizer.view;
@@ -529,6 +527,7 @@
     [self defaultSetup];
 }
 - (void)selectTabAtIndex:(NSUInteger)index {
+    self.animatingToTab = YES;
     
     // Set activeTabIndex
     self.activeTabIndex = index;


### PR DESCRIPTION
You can see the underlying bug in the sample app prior to this patch. 

Run the sample app and turn on slow animations (cmd + t in the simulator). Tap the 'Tab #5' button and notice that the tab bar immediately changes to tab 5, then animates left, then jumps back to center on tab 5.  

In the debugger you can see that this is because it's hitting [self.tabsView scrollRectToVisible:frame animated:NO] in scrollViewDidScroll: as a result of the call to selectTabAtIndex

You've already got a mechanism to avoid this (self.animatingToTab = YES), so I invoked it in this case. I couldn't find a way this would be problematic based on other places you call selectTabAtIndex, but it's possible I'm missing something.
