### PR TITLE
Fixed Issue #35.

### DIFF
--- a/ICViewPager/ICViewPager/ViewPagerController.m
+++ b/ICViewPager/ICViewPager/ViewPagerController.m
@@ -567,6 +567,11 @@
     [self defaultSetup];
 }
 - (void)selectTabAtIndex:(NSUInteger)index {
+    
+    if (index >= self.tabCount) {
+        return;
+    }
+    
     self.animatingToTab = YES;
     
     // Set activeTabIndex


### PR DESCRIPTION
This should fix monsieurje/ICViewPager#35.

The first plan for this fix was just to workaround not to pass
`NSNotFound` to `selectTabAtIndex:`, but I found `selectTabAtIndex:`
doesn't take out-of-bounds arguments into account. In private methods
like `viewControllerAtIndex:` handles invalid arguments collectly so I
decided follow this way. Notice that `selectTabAtIndex:` is a public
method which behaviour will be changed by this fix.
