### PR TITLE
Fixed a tab scrolling bug.

### DIFF
--- a/ICViewPager/ICViewPager/ViewPagerController.m
+++ b/ICViewPager/ICViewPager/ViewPagerController.m
@@ -372,7 +372,9 @@
         [self.pageViewController setViewControllers:@[viewController]
                                           direction:UIPageViewControllerNavigationDirectionForward
                                            animated:NO
-                                         completion:nil];
+                                         completion:^(BOOL completed) {
+                                             weakSelf.animatingToTab = NO;
+                                         }];
         
     } else if (!(activeContentIndex + 1 == self.activeContentIndex || activeContentIndex - 1 == self.activeContentIndex)) {
         
@@ -397,7 +399,9 @@
         [self.pageViewController setViewControllers:@[viewController]
                                           direction:(activeContentIndex < self.activeContentIndex) ? UIPageViewControllerNavigationDirectionReverse : UIPageViewControllerNavigationDirectionForward
                                            animated:YES
-                                         completion:nil];
+                                         completion:^(BOOL completed) {
+                                             weakSelf.animatingToTab = NO;
+                                         }];
     }
     
     // Clean out of sight contents


### PR DESCRIPTION
Before this, sometimes tab won't follow by scrolling when content view
is paged by swipe gestures. This was caused when `animatingToTab`
property is set to `YES` and never gets back to `NO` again. So I just
worked around this by adding a completion handler to cases that was not
handling this property. I'm not sure that was intentional or not, but
for me this fix works well.
