### PR TITLE
Adjust frame height if tabBar is hidden

### DIFF
--- a/ICViewPager/ICViewPager/ViewPagerController.m
+++ b/ICViewPager/ICViewPager/ViewPagerController.m
@@ -221,7 +221,7 @@
     frame.origin.x = 0.0;
     frame.origin.y = [self.tabLocation boolValue] ? topLayoutGuide + CGRectGetHeight(self.tabsView.frame) : topLayoutGuide;
     frame.size.width = CGRectGetWidth(self.view.frame);
-    frame.size.height = CGRectGetHeight(self.view.frame) - (topLayoutGuide + CGRectGetHeight(self.tabsView.frame)) - CGRectGetHeight(self.tabBarController.tabBar.frame);
+    frame.size.height = CGRectGetHeight(self.view.frame) - (topLayoutGuide + CGRectGetHeight(self.tabsView.frame)) - (self.tabBarController.tabBar.hidden ? 0 : CGRectGetHeight(self.tabBarController.tabBar.frame));
     self.contentView.frame = frame;
 }
 


### PR DESCRIPTION
When a tabBarController is present, but hidden, this fix prevents the view from resizing to make room for the hidden tabBar (which previously resulted in a white bar). If the tabBar is shown, this change has no effect.
