### PR TITLE
Fixed "Unrecognized selector" crash with selectedTabAtIndex: getter.

### DIFF
--- a/ICViewPager/ICViewPager/ViewPagerController.m
+++ b/ICViewPager/ICViewPager/ViewPagerController.m
@@ -573,6 +573,11 @@
     // Call to setup again with the updated data
     [self defaultSetup];
 }
+
+- (void)selectTabAtIndex:(NSUInteger)index {
+    [self selectTabAtIndex:index didSwipe:NO];
+}
+
 - (void)selectTabAtIndex:(NSUInteger)index didSwipe:(BOOL)didSwipe {
     
     if (index >= self.tabCount) {


### PR DESCRIPTION
Unfortunately my last commit introduced a bug due to the header file still having the old method of selectTabAtIndex:(NSUInteger)index. This commit fixes the problem with subclasses calling said method.
