### PR TITLE
Fix crash when switch the data source

### DIFF
--- a/ICViewPager/ICViewPager/ViewPagerController.m
+++ b/ICViewPager/ICViewPager/ViewPagerController.m
@@ -411,13 +411,15 @@
     NSInteger index;
     index = self.activeContentIndex - 1;
     if (index >= 0 &&
+		index < self.contents.count &&
         index != activeContentIndex &&
         index != activeContentIndex - 1)
     {
         [self.contents replaceObjectAtIndex:index withObject:[NSNull null]];
     }
     index = self.activeContentIndex;
-    if (index != activeContentIndex - 1 &&
+    if (index < self.contents.count &&
+		index != activeContentIndex - 1 &&
         index != activeContentIndex &&
         index != activeContentIndex + 1)
     {


### PR DESCRIPTION
crash (100%) steps:
1. set the ViewPagerController’s data source, total count is 10;
2. select the active page as 9;
3. i want to change the data source to another data source, total count maybe
is 5. So i call ViewPagerController reloadData.
4. ViewPagerController crash, out of range exception

Root Cause is self.activeContentIndex is still 9,  NSArray cash when
call [self.contents replaceObjectAtIndex:index withObject:[NSNull null]]
